### PR TITLE
Compatibilidade com Laravel 6.x (Função str_random por Str::random)

### DIFF
--- a/src/PDFMerger.php
+++ b/src/PDFMerger.php
@@ -117,7 +117,7 @@ class PDFMerger {
      * @return void
      */
     public function addPDFString($string, $pages = 'all', $orientation = null){
-        $filePath = storage_path('tmp/'.str_random(16).'.pdf');
+        $filePath = storage_path('tmp/'.\Str::random(16).'.pdf');
         $this->filesystem->put($filePath, $string);
         $this->tmpFiles->push($filePath);
         return $this->addPathToPDF($filePath, $pages, $orientation);
@@ -208,7 +208,7 @@ class PDFMerger {
       preg_match_all('!\d+!', $first_line, $matches);
       $pdfversion = implode('.', $matches[0]);
       if($pdfversion > "1.4"){
-        $newFilePath = storage_path('tmp/' . str_random(16) . '.pdf');
+        $newFilePath = storage_path('tmp/' . \Str::random(16) . '.pdf');
         //execute shell script that converts PDF to correct version and saves it to tmp folder
         shell_exec('gs -dBATCH -dNOPAUSE -q -sDEVICE=pdfwrite -sOutputFile="'. $newFilePath . '" "' . $filePath . '"');
         $this->tmpFiles->push($newFilePath);


### PR DESCRIPTION
A versão do Laravel 6.x não existe mais a função str_random, foi substituída por Str::random. 