### PR TITLE
Dynamic orientation

### DIFF
--- a/src/PDFMerger.php
+++ b/src/PDFMerger.php
@@ -167,14 +167,13 @@ class PDFMerger {
       $fpdi = $this->fpdi;
       $files = $this->files;
       foreach($files as $index => $file){
-        $file['orientation'] = is_null($file['orientation']) ? $orientation : $file['orientation'];
         $count = $fpdi->setSourceFile($file['name']);
         if($file['pages'] == 'all') {
           $pages = $count;
           for ($i = 1; $i <= $count; $i++) {
             $template   = $fpdi->importPage($i);
             $size       = $fpdi->getTemplateSize($template);
-            $fpdi->AddPage($file['orientation'], [$size['width'], $size['height']]);
+            $fpdi->AddPage($file['orientation']??$size['orientation'], [$size['width'], $size['height']]);
             $fpdi->useTemplate($template);
           }
         }else {

--- a/src/PDFMerger.php
+++ b/src/PDFMerger.php
@@ -183,12 +183,12 @@ class PDFMerger {
               throw new \Exception("Could not load page '$page' in PDF '".$file['name']."'. Check that the page exists.");
             }
             $size = $fpdi->getTemplateSize($template);
-            $fpdi->AddPage($file['orientation'], [$size['width'], $size['height']]);
+            $fpdi->AddPage($file['orientation']??$size['orientation'], [$size['width'], $size['height']]);
             $fpdi->useTemplate($template);
           }
         }
         if ($duplex && $pages % 2 && $index < (count($files) - 1)) {
-          $fpdi->AddPage($file['orientation'], [$size['width'], $size['height']]);
+          $fpdi->AddPage($file['orientation']??$size['orientation'], [$size['width'], $size['height']]);
         }
       }
     }


### PR DESCRIPTION
If a file is added using addPathToPdf() method and orientation is given null or not given at all, the orientation will be set to the original orientation of the file instead of default portrait.